### PR TITLE
feat(debugger): implement expression evaluator (closes #45)

### DIFF
--- a/src/debugger/inspector.rs
+++ b/src/debugger/inspector.rs
@@ -90,13 +90,202 @@ impl DebugInspector {
 
     /// Evaluate an expression in the current context
     pub fn evaluate(&self, expression: &str) -> Result<String, DebuggerError> {
-        // In a real implementation, this would parse and evaluate the expression
-        // in the context of the current state
-        // For now, just return an error
-        Err(DebuggerError::Generic(format!(
-            "Expression evaluation not implemented: {}",
-            expression
-        )))
+        let expr = expression.trim();
+        if expr.is_empty() {
+            return Err(DebuggerError::Generic("Empty expression".to_string()));
+        }
+
+        match self.eval_expression(expr) {
+            Ok(value) => Ok(value),
+            Err(e) => Err(DebuggerError::Generic(e)),
+        }
+    }
+
+    fn eval_expression(&self, expr: &str) -> Result<String, String> {
+        let expr = expr.trim();
+
+        // Try parsing as comparison first
+        if let Some(pos) = self.find_operator(expr, &["==", "!=", "<=", ">="]) {
+            let left = &expr[..pos];
+            let op = &expr[pos..pos + 2];
+            let right = &expr[pos + 2..];
+            return self.eval_comparison(left, op, right);
+        }
+
+        if let Some(pos) = self.find_operator(expr, &["<", ">"]) {
+            let left = &expr[..pos];
+            let op = &expr[pos..pos + 1];
+            let right = &expr[pos + 1..];
+            return self.eval_comparison(left, op, right);
+        }
+
+        // Try parsing as addition/subtraction
+        self.eval_add_sub(expr)
+    }
+
+    fn eval_add_sub(&self, expr: &str) -> Result<String, String> {
+        let expr = expr.trim();
+
+        let mut depth: i32 = 0;
+        let mut last_add_sub = None;
+
+        for (i, c) in expr.char_indices().rev() {
+            match c {
+                ')' => depth += 1,
+                '(' => depth = depth.saturating_sub(1),
+                '+' | '-' if depth == 0 => {
+                    if i > 0 {
+                        last_add_sub = Some(i);
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(pos) = last_add_sub {
+            let left = &expr[..pos];
+            let op = expr[pos..=pos].to_string();
+            let right = &expr[pos + 1..];
+            let left_val = self
+                .eval_mul_div(left)?
+                .parse::<i64>()
+                .map_err(|_| "Invalid left operand")?;
+            let right_val = self
+                .eval_add_sub(right)?
+                .parse::<i64>()
+                .map_err(|_| "Invalid right operand")?;
+            let result = if op == "+" {
+                left_val + right_val
+            } else {
+                left_val - right_val
+            };
+            return Ok(result.to_string());
+        }
+
+        self.eval_mul_div(expr)
+    }
+
+    fn eval_mul_div(&self, expr: &str) -> Result<String, String> {
+        let expr = expr.trim();
+
+        let mut depth: i32 = 0;
+        let mut last_mul_div = None;
+
+        for (i, c) in expr.char_indices().rev() {
+            match c {
+                ')' => depth += 1,
+                '(' => depth = depth.saturating_sub(1),
+                '*' | '/' if depth == 0 => {
+                    last_mul_div = Some(i);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(pos) = last_mul_div {
+            let left = &expr[..pos];
+            let op = expr[pos..=pos].to_string();
+            let right = &expr[pos + 1..];
+            let left_val = self
+                .eval_primary(left)?
+                .parse::<i64>()
+                .map_err(|_| "Invalid left operand")?;
+            let right_val = self
+                .eval_mul_div(right)?
+                .parse::<i64>()
+                .map_err(|_| "Invalid right operand")?;
+            let result = if op == "*" {
+                left_val * right_val
+            } else {
+                if right_val == 0 {
+                    return Err("Division by zero".to_string());
+                }
+                left_val / right_val
+            };
+            return Ok(result.to_string());
+        }
+
+        self.eval_primary(expr)
+    }
+
+    fn eval_primary(&self, expr: &str) -> Result<String, String> {
+        let expr = expr.trim();
+
+        // Handle parentheses
+        if expr.starts_with('(') && expr.ends_with(')') {
+            let inner = &expr[1..expr.len() - 1];
+            return self.eval_expression(inner);
+        }
+
+        // Try to parse as number
+        if let Ok(num) = expr.parse::<i64>() {
+            return Ok(num.to_string());
+        }
+
+        // Try to parse as boolean comparison result
+        if expr == "true" {
+            return Ok("true".to_string());
+        }
+        if expr == "false" {
+            return Ok("false".to_string());
+        }
+
+        // Try to look up variable
+        if let Some(value) = self.state.get_local_variable(expr) {
+            return Ok(value.to_string());
+        }
+
+        // Try to look up register
+        if let Some(value) = self.state.get_register(expr) {
+            return Ok(value.to_string());
+        }
+
+        Err(format!("Unknown identifier: {}", expr))
+    }
+
+    fn eval_comparison(&self, left: &str, op: &str, right: &str) -> Result<String, String> {
+        let left_val = self
+            .eval_add_sub(left)?
+            .parse::<i64>()
+            .map_err(|_| "Invalid left operand")?;
+        let right_val = self
+            .eval_add_sub(right)?
+            .parse::<i64>()
+            .map_err(|_| "Invalid right operand")?;
+
+        let result = match op {
+            "==" => left_val == right_val,
+            "!=" => left_val != right_val,
+            "<" => left_val < right_val,
+            ">" => left_val > right_val,
+            "<=" => left_val <= right_val,
+            ">=" => left_val >= right_val,
+            _ => return Err(format!("Unknown operator: {}", op)),
+        };
+
+        Ok(if result { "true" } else { "false" }.to_string())
+    }
+
+    fn find_operator<'a>(&self, expr: &str, ops: &[&str]) -> Option<usize> {
+        let mut depth: i32 = 0;
+
+        for (i, c) in expr.char_indices().rev() {
+            match c {
+                ')' => depth += 1,
+                '(' => depth = depth.saturating_sub(1),
+                _ if depth == 0 => {
+                    for op in ops {
+                        if expr[i..].starts_with(op) {
+                            return Some(i);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
     }
 
     /// Get the call stack

--- a/tests/debugger_tests.rs
+++ b/tests/debugger_tests.rs
@@ -1,0 +1,329 @@
+use bend_pvm::debugger::{
+    breakpoint::Breakpoint,
+    state::{DebuggerState, ExecutionState},
+    DebugInfo, FunctionRange, VariableLocation,
+};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[cfg(test)]
+mod debugger_state_tests {
+    use super::*;
+
+    #[test]
+    fn test_debugger_state_new() {
+        let state = DebuggerState::new();
+        assert_eq!(state.execution_state, ExecutionState::Stopped);
+        assert_eq!(state.pc, 0);
+        assert!(state.call_stack.is_empty());
+        assert!(state.registers.is_empty());
+    }
+
+    #[test]
+    fn test_set_and_get_register() {
+        let mut state = DebuggerState::new();
+        state.set_register("x1", 42);
+        assert_eq!(state.get_register("x1"), Some(42));
+    }
+
+    #[test]
+    fn test_set_and_get_memory() {
+        let mut state = DebuggerState::new();
+        state.set_memory(0x1000, 0xAB);
+        assert_eq!(state.get_memory(0x1000), Some(0xAB));
+    }
+
+    #[test]
+    fn test_set_and_get_local_variable() {
+        let mut state = DebuggerState::new();
+        state.set_local_variable("counter", 100);
+        assert_eq!(state.get_local_variable("counter"), Some(100));
+    }
+
+    #[test]
+    fn test_call_stack_push_pop() {
+        let mut state = DebuggerState::new();
+        state.call_stack.push("main".to_string());
+        state.call_stack.push("helper".to_string());
+        assert_eq!(state.current_function(), Some("helper"));
+        state.call_stack.pop();
+        assert_eq!(state.current_function(), Some("main"));
+    }
+
+    #[test]
+    fn test_reset_clears_state() {
+        let mut state = DebuggerState::new();
+        state.set_register("x1", 42);
+        state.set_memory(0x1000, 0xAB);
+        state.pc = 100;
+        state.call_stack.push("test".to_string());
+
+        state.reset();
+
+        assert_eq!(state.execution_state, ExecutionState::Stopped);
+        assert_eq!(state.pc, 0);
+        assert!(state.call_stack.is_empty());
+        assert!(state.registers.is_empty());
+        assert!(state.memory.is_empty());
+    }
+
+    #[test]
+    fn test_execution_state_transitions() {
+        let mut state = DebuggerState::new();
+        assert_eq!(state.execution_state, ExecutionState::Stopped);
+
+        state.execution_state = ExecutionState::Running;
+        assert_eq!(state.execution_state, ExecutionState::Running);
+
+        state.execution_state = ExecutionState::Paused;
+        assert_eq!(state.execution_state, ExecutionState::Paused);
+    }
+}
+
+#[cfg(test)]
+mod breakpoint_tests {
+    use super::*;
+
+    #[test]
+    fn test_breakpoint_line_creation() {
+        let bp = Breakpoint::line(42);
+        assert_eq!(bp, Breakpoint::Line(42));
+    }
+
+    #[test]
+    fn test_breakpoint_instruction_creation() {
+        let bp = Breakpoint::instruction(100);
+        assert_eq!(bp, Breakpoint::Instruction(100));
+    }
+
+    #[test]
+    fn test_breakpoint_function_creation() {
+        let bp = Breakpoint::function("main");
+        assert_eq!(bp, Breakpoint::Function("main".to_string()));
+    }
+
+    #[test]
+    fn test_breakpoint_description() {
+        let bp = Breakpoint::Line(42);
+        assert_eq!(bp.description(), "Line 42");
+
+        let bp = Breakpoint::Instruction(100);
+        assert_eq!(bp.description(), "Instruction 100");
+
+        let bp = Breakpoint::Function("main".to_string());
+        assert_eq!(bp.description(), "Function main");
+    }
+}
+
+#[cfg(test)]
+mod debug_info_tests {
+    use super::*;
+
+    fn create_test_debug_info() -> DebugInfo {
+        DebugInfo {
+            source_path: PathBuf::from("test.bend"),
+            source_code: "fn main() {\n    let x = 1;\n    let y = 2;\n}".to_string(),
+            line_to_instruction: HashMap::from([(1, vec![0]), (2, vec![1]), (3, vec![2])]),
+            instruction_to_line: HashMap::from([(0, 1), (1, 2), (2, 3)]),
+            functions: HashMap::from([(
+                "main".to_string(),
+                FunctionRange {
+                    name: "main".to_string(),
+                    start: 0,
+                    end: 10,
+                    start_line: 1,
+                    end_line: 3,
+                },
+            )]),
+            locals: HashMap::from([
+                ("x".to_string(), VariableLocation::Stack(4)),
+                ("y".to_string(), VariableLocation::Stack(8)),
+            ]),
+        }
+    }
+
+    #[test]
+    fn test_debug_info_creation() {
+        let debug_info = create_test_debug_info();
+        assert_eq!(debug_info.source_path, PathBuf::from("test.bend"));
+        assert_eq!(debug_info.line_to_instruction.len(), 3);
+        assert_eq!(debug_info.instruction_to_line.len(), 3);
+    }
+
+    #[test]
+    fn test_line_to_instruction_mapping() {
+        let debug_info = create_test_debug_info();
+        assert_eq!(debug_info.line_to_instruction.get(&1), Some(&vec![0]));
+        assert_eq!(debug_info.line_to_instruction.get(&2), Some(&vec![1]));
+    }
+
+    #[test]
+    fn test_instruction_to_line_mapping() {
+        let debug_info = create_test_debug_info();
+        assert_eq!(debug_info.instruction_to_line.get(&0), Some(&1));
+        assert_eq!(debug_info.instruction_to_line.get(&1), Some(&2));
+    }
+
+    #[test]
+    fn test_function_ranges() {
+        let debug_info = create_test_debug_info();
+        let func = debug_info.functions.get("main").unwrap();
+        assert_eq!(func.name, "main");
+        assert_eq!(func.start, 0);
+        assert_eq!(func.end, 10);
+    }
+
+    #[test]
+    fn test_locals_mapping() {
+        let debug_info = create_test_debug_info();
+        if let Some(loc) = debug_info.locals.get("x") {
+            assert!(matches!(loc, VariableLocation::Stack(4)));
+        } else {
+            panic!("x not found in locals");
+        }
+        if let Some(loc) = debug_info.locals.get("y") {
+            assert!(matches!(loc, VariableLocation::Stack(8)));
+        } else {
+            panic!("y not found in locals");
+        }
+    }
+}
+
+#[cfg(test)]
+mod expression_evaluator_tests {
+    use super::*;
+    use bend_pvm::debugger::inspector::DebugInspector;
+
+    fn create_test_inspector() -> DebugInspector {
+        let debug_info = DebugInfo {
+            source_path: PathBuf::from("test.bend"),
+            source_code: "fn main() {\n    let x = 1;\n    let y = 2;\n}".to_string(),
+            line_to_instruction: HashMap::new(),
+            instruction_to_line: HashMap::new(),
+            functions: HashMap::new(),
+            locals: HashMap::from([
+                ("x".to_string(), VariableLocation::Stack(4)),
+                ("y".to_string(), VariableLocation::Stack(8)),
+            ]),
+        };
+
+        let mut state = DebuggerState::new();
+        state.set_local_variable("x", 10);
+        state.set_local_variable("y", 20);
+        state.registers.insert("x1".to_string(), 5);
+        state.registers.insert("x2".to_string(), 15);
+
+        DebugInspector::new(debug_info, state, Vec::new())
+    }
+
+    #[test]
+    fn test_evaluate_literal_number() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("42");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "42");
+    }
+
+    #[test]
+    fn test_evaluate_simple_addition() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("5 + 3");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "8");
+    }
+
+    #[test]
+    fn test_evaluate_simple_subtraction() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("10 - 4");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "6");
+    }
+
+    #[test]
+    fn test_evaluate_simple_multiplication() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("6 * 7");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "42");
+    }
+
+    #[test]
+    fn test_evaluate_simple_division() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("20 / 4");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "5");
+    }
+
+    #[test]
+    fn test_evaluate_local_variable() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("x");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "10");
+    }
+
+    #[test]
+    fn test_evaluate_register() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("x1");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "5");
+    }
+
+    #[test]
+    fn test_evaluate_expression_with_variables() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("x + y");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "30");
+    }
+
+    #[test]
+    fn test_evaluate_complex_expression() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("(x + y) * 2");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "60");
+    }
+
+    #[test]
+    fn test_evaluate_comparison_equality() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("5 == 5");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "true");
+    }
+
+    #[test]
+    fn test_evaluate_comparison_inequality() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("5 != 3");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "true");
+    }
+
+    #[test]
+    fn test_evaluate_comparison_less_than() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("3 < 5");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "true");
+    }
+
+    #[test]
+    fn test_evaluate_comparison_greater_than() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("10 > 5");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "true");
+    }
+
+    #[test]
+    fn test_evaluate_undefined_variable_returns_error() {
+        let inspector = create_test_inspector();
+        let result = inspector.evaluate("undefined_var");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Add 30 TDD tests for debugger functionality
- Implement expression evaluator supporting arithmetic and comparisons
- Return 'true'/'false' strings for comparison results

## Tests Added
- `debugger_state_tests`: 7 tests for state management
- `breakpoint_tests`: 4 tests for breakpoint creation
- `debug_info_tests`: 6 tests for debug information tracking  
- `expression_evaluator_tests`: 13 tests for expression evaluation

## Implementation
- `evaluate()` - main entry point for expression evaluation
- `eval_expression()` - handles comparison operators (==, !=, <, >, <=, >=)
- `eval_add_sub()` - handles addition and subtraction
- `eval_mul_div()` - handles multiplication and division
- `eval_primary()` - handles literals, variables, registers, parentheses

Closes #45