### PR TITLE
feat(package): add package manager module (closes #21)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@ pub mod testing;
 // Analyzer tools
 pub mod analyzer;
 
+// Package manager
+pub mod package;
+
 use std::path::PathBuf;
 use thiserror::Error;
 

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -1,0 +1,6 @@
+pub mod package;
+
+pub use package::{
+    Dependency, DependencyResolver, Package, PackageError, PackageLock, PackageLockEntry,
+    PackageManifest, PackageMetadata, PackageRegistry, Version,
+};

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -1,0 +1,466 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl Version {
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Version {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self, PackageError> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err(PackageError::InvalidVersion(s.to_string()));
+        }
+
+        let major = parts[0]
+            .parse()
+            .map_err(|_| PackageError::InvalidVersion(s.to_string()))?;
+        let minor = parts[1]
+            .parse()
+            .map_err(|_| PackageError::InvalidVersion(s.to_string()))?;
+        let patch = parts[2]
+            .parse()
+            .map_err(|_| PackageError::InvalidVersion(s.to_string()))?;
+
+        Ok(Version::new(major, minor, patch))
+    }
+
+    pub fn from_str(s: &str) -> Result<Self, PackageError> {
+        Self::parse(s)
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.major
+            .cmp(&other.major)
+            .then(self.minor.cmp(&other.minor))
+            .then(self.patch.cmp(&other.patch))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dependency {
+    name: String,
+    version: Version,
+}
+
+impl Dependency {
+    pub fn new(name: String, version: Version) -> Self {
+        Dependency { name, version }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+
+    pub fn is_satisfied_by(&self, version: &Version) -> bool {
+        version.major == self.version.major && version >= &self.version
+    }
+}
+
+impl PartialEq for Dependency {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.version == other.version
+    }
+}
+
+impl Eq for Dependency {}
+
+#[derive(Debug, Clone)]
+pub struct PackageMetadata {
+    description: Option<String>,
+    authors: Vec<String>,
+    license: Option<String>,
+    repository: Option<String>,
+}
+
+impl PackageMetadata {
+    pub fn new() -> Self {
+        PackageMetadata {
+            description: None,
+            authors: Vec::new(),
+            license: None,
+            repository: None,
+        }
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    pub fn authors(&self) -> &[String] {
+        &self.authors
+    }
+
+    pub fn license(&self) -> Option<&str> {
+        self.license.as_deref()
+    }
+
+    pub fn repository(&self) -> Option<&str> {
+        self.repository.as_deref()
+    }
+
+    pub fn set_description(&mut self, desc: String) {
+        self.description = Some(desc);
+    }
+
+    pub fn add_author(&mut self, author: String) {
+        self.authors.push(author);
+    }
+
+    pub fn set_license(&mut self, license: String) {
+        self.license = Some(license);
+    }
+
+    pub fn set_repository(&mut self, repo: String) {
+        self.repository = Some(repo);
+    }
+}
+
+impl Default for PackageMetadata {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Package {
+    name: String,
+    version: Version,
+    metadata: PackageMetadata,
+    dependencies: Vec<Dependency>,
+}
+
+impl Package {
+    pub fn new(name: String, version: Version) -> Self {
+        Package {
+            name,
+            version,
+            metadata: PackageMetadata::new(),
+            dependencies: Vec::new(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        self.metadata.description()
+    }
+
+    pub fn authors(&self) -> &[String] {
+        self.metadata.authors()
+    }
+
+    pub fn dependencies(&self) -> &[Dependency] {
+        &self.dependencies
+    }
+
+    pub fn metadata(&self) -> &PackageMetadata {
+        &self.metadata
+    }
+
+    pub fn set_description(&mut self, desc: String) {
+        self.metadata.set_description(desc);
+    }
+
+    pub fn add_author(&mut self, author: String) {
+        self.metadata.add_author(author);
+    }
+
+    pub fn add_dependency(&mut self, dep: Dependency) {
+        self.dependencies.push(dep);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageManifest {
+    package: Package,
+}
+
+impl PackageManifest {
+    pub fn new(name: String, version: Version) -> Self {
+        PackageManifest {
+            package: Package::new(name, version),
+        }
+    }
+
+    pub fn package(&self) -> &Package {
+        &self.package
+    }
+
+    pub fn package_mut(&mut self) -> &mut Package {
+        &mut self.package
+    }
+
+    pub fn dependencies(&self) -> &[Dependency] {
+        self.package.dependencies()
+    }
+
+    pub fn add_dependency(&mut self, name: String, version: Version) {
+        self.package.add_dependency(Dependency::new(name, version));
+    }
+
+    pub fn validate(&self) -> Result<(), PackageError> {
+        if self.package.name.is_empty() {
+            return Err(PackageError::InvalidName(self.package.name.clone()));
+        }
+        if !Self::is_valid_name(&self.package.name) {
+            return Err(PackageError::InvalidName(self.package.name.clone()));
+        }
+        Ok(())
+    }
+
+    pub fn is_valid_name(name: &str) -> bool {
+        !name.is_empty()
+            && !name.starts_with('-')
+            && name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageLockEntry {
+    name: String,
+    version: Version,
+    integrity: String,
+}
+
+impl PackageLockEntry {
+    pub fn new(name: String, version: Version, integrity: String) -> Self {
+        PackageLockEntry {
+            name,
+            version,
+            integrity,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+
+    pub fn integrity(&self) -> &str {
+        &self.integrity
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageLock {
+    entries: HashMap<String, PackageLockEntry>,
+}
+
+impl PackageLock {
+    pub fn new() -> Self {
+        PackageLock {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn entries(&self) -> &HashMap<String, PackageLockEntry> {
+        &self.entries
+    }
+
+    pub fn add_entry(&mut self, entry: PackageLockEntry) {
+        self.entries.insert(entry.name().to_string(), entry);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&PackageLockEntry> {
+        self.entries.get(name)
+    }
+}
+
+impl Default for PackageLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackageRegistry {
+    packages: HashMap<String, Package>,
+}
+
+impl PackageRegistry {
+    pub fn new() -> Self {
+        PackageRegistry {
+            packages: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, package: Package) -> Result<(), PackageError> {
+        let name = package.name().to_string();
+        if self.packages.contains_key(&name) {
+            return Err(PackageError::AlreadyExists(name));
+        }
+        self.packages.insert(name, package);
+        Ok(())
+    }
+
+    pub fn exists(&self, name: &str) -> bool {
+        self.packages.contains_key(name)
+    }
+
+    pub fn get(&self, name: &str) -> Option<&Package> {
+        self.packages.get(name)
+    }
+
+    pub fn list(&self) -> Vec<&Package> {
+        self.packages.values().collect()
+    }
+}
+
+impl Default for PackageRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DependencyResolver {
+    packages: HashMap<String, Version>,
+}
+
+impl DependencyResolver {
+    pub fn new() -> Self {
+        DependencyResolver {
+            packages: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, package: Package) -> Result<(), PackageError> {
+        let name = package.name().to_string();
+        let version = package.version().clone();
+
+        if let Some(existing) = self.packages.get(&name) {
+            if existing != &version {
+                return Err(PackageError::VersionConflict {
+                    package: name,
+                    version1: existing.clone(),
+                    version2: version,
+                });
+            }
+        }
+
+        self.packages.insert(name, version);
+        Ok(())
+    }
+
+    pub fn resolve(&self, package: &Package) -> Result<Vec<Package>, PackageError> {
+        let mut resolved = Vec::new();
+        resolved.push(package.clone());
+
+        for dep in package.dependencies() {
+            if let Some(version) = self.packages.get(dep.name()) {
+                if !dep.is_satisfied_by(version) {
+                    return Err(PackageError::UnsatisfiedDependency {
+                        package: dep.name().to_string(),
+                        required: dep.version().clone(),
+                        available: version.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(resolved)
+    }
+}
+
+impl Default for DependencyResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PackageError {
+    InvalidName(String),
+    InvalidVersion(String),
+    AlreadyExists(String),
+    VersionConflict {
+        package: String,
+        version1: Version,
+        version2: Version,
+    },
+    UnsatisfiedDependency {
+        package: String,
+        required: Version,
+        available: Version,
+    },
+}
+
+impl std::fmt::Display for PackageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PackageError::InvalidName(name) => {
+                write!(f, "Invalid package name: {}", name)
+            }
+            PackageError::InvalidVersion(version) => {
+                write!(f, "Invalid version: {}", version)
+            }
+            PackageError::AlreadyExists(name) => {
+                write!(f, "Package already exists: {}", name)
+            }
+            PackageError::VersionConflict {
+                package,
+                version1,
+                version2,
+            } => {
+                write!(
+                    f,
+                    "Version conflict for {}: {} vs {}",
+                    package, version1, version2
+                )
+            }
+            PackageError::UnsatisfiedDependency {
+                package,
+                required,
+                available,
+            } => {
+                write!(
+                    f,
+                    "Unsatisfied dependency {}: required {} but available {}",
+                    package, required, available
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PackageError {}

--- a/tests/package_tests.rs
+++ b/tests/package_tests.rs
@@ -1,0 +1,219 @@
+use bend_pvm::package::{
+    Dependency, Package, PackageError, PackageManifest, PackageMetadata, Version,
+};
+
+fn create_test_package() -> Package {
+    Package::new("test_pkg".to_string(), Version::new(1, 0, 0))
+}
+
+mod package_tests {
+    use super::*;
+
+    #[test]
+    fn test_version_creation() {
+        let version = Version::new(1, 2, 3);
+        assert_eq!(version.major, 1);
+        assert_eq!(version.minor, 2);
+        assert_eq!(version.patch, 3);
+    }
+
+    #[test]
+    fn test_version_to_string() {
+        let version = Version::new(1, 2, 3);
+        assert_eq!(version.to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn test_version_parse() {
+        let version = Version::parse("2.1.0").unwrap();
+        assert_eq!(version.major, 2);
+        assert_eq!(version.minor, 1);
+        assert_eq!(version.patch, 0);
+    }
+
+    #[test]
+    fn test_version_parse_invalid() {
+        let result = Version::parse("invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_version_eq() {
+        let v1 = Version::new(1, 0, 0);
+        let v2 = Version::new(1, 0, 0);
+        assert_eq!(v1, v2);
+    }
+
+    #[test]
+    fn test_version_cmp() {
+        let v1 = Version::new(1, 0, 0);
+        let v2 = Version::new(2, 0, 0);
+        assert!(v1 < v2);
+    }
+
+    #[test]
+    fn test_package_creation() {
+        let pkg = create_test_package();
+        assert_eq!(pkg.name(), "test_pkg");
+        assert_eq!(pkg.version().major, 1);
+        assert_eq!(pkg.version().minor, 0);
+        assert_eq!(pkg.version().patch, 0);
+    }
+
+    #[test]
+    fn test_package_metadata() {
+        let mut pkg = create_test_package();
+        pkg.set_description("A test package".to_string());
+        pkg.add_author("Test Author".to_string());
+
+        assert_eq!(pkg.description(), Some("A test package"));
+        assert!(pkg.authors().contains(&"Test Author".to_string()));
+    }
+
+    #[test]
+    fn test_package_with_dependencies() {
+        let mut pkg = create_test_package();
+        let dep = Dependency::new("other_pkg".to_string(), Version::new(1, 0, 0));
+        pkg.add_dependency(dep.clone());
+
+        assert!(pkg.dependencies().contains(&dep));
+    }
+
+    #[test]
+    fn test_package_manifest_creation() {
+        let manifest = PackageManifest::new("my_pkg".to_string(), Version::new(1, 0, 0));
+        assert_eq!(manifest.package().name(), "my_pkg");
+        assert!(manifest.validate().is_ok());
+    }
+
+    #[test]
+    fn test_package_manifest_invalid_name() {
+        let manifest = PackageManifest::new("".to_string(), Version::new(1, 0, 0));
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn test_package_manifest_with_dependencies() {
+        let mut manifest = PackageManifest::new("my_pkg".to_string(), Version::new(1, 0, 0));
+        manifest.add_dependency("dep_pkg".to_string(), Version::new(2, 0, 0));
+
+        assert!(manifest.validate().is_ok());
+        assert_eq!(manifest.dependencies().len(), 1);
+    }
+
+    #[test]
+    fn test_dependency_satisfied_by() {
+        let dep = Dependency::new("pkg".to_string(), Version::new(1, 0, 0));
+
+        assert!(dep.is_satisfied_by(&Version::new(1, 0, 0)));
+        assert!(dep.is_satisfied_by(&Version::new(1, 5, 0)));
+        assert!(!dep.is_satisfied_by(&Version::new(2, 0, 0)));
+        assert!(!dep.is_satisfied_by(&Version::new(0, 9, 0)));
+    }
+
+    #[test]
+    fn test_package_error_display() {
+        let err = PackageError::InvalidName("bad".to_string());
+        assert!(err.to_string().contains("Invalid package name"));
+
+        let err = PackageError::InvalidVersion("bad".to_string());
+        assert!(err.to_string().contains("Invalid version"));
+    }
+
+    #[test]
+    fn test_package_lock_entry() {
+        use bend_pvm::package::PackageLockEntry;
+
+        let entry = PackageLockEntry::new(
+            "locked_pkg".to_string(),
+            Version::new(1, 0, 0),
+            "sha256:abc123".to_string(),
+        );
+
+        assert_eq!(entry.name(), "locked_pkg");
+        assert_eq!(entry.version().major, 1);
+        assert_eq!(entry.integrity(), "sha256:abc123");
+    }
+
+    #[test]
+    fn test_package_registry() {
+        use bend_pvm::package::PackageRegistry;
+
+        let mut registry = PackageRegistry::new();
+        let pkg = create_test_package();
+
+        registry.register(pkg.clone()).unwrap();
+        assert!(registry.exists("test_pkg"));
+        assert_eq!(registry.get("test_pkg").unwrap().name(), "test_pkg");
+    }
+
+    #[test]
+    fn test_package_registry_duplicate() {
+        use bend_pvm::package::PackageRegistry;
+
+        let mut registry = PackageRegistry::new();
+        let pkg = create_test_package();
+
+        registry.register(pkg.clone()).unwrap();
+        let result = registry.register(pkg);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_package_resolver() {
+        use bend_pvm::package::DependencyResolver;
+
+        let resolver = DependencyResolver::new();
+        let pkg = create_test_package();
+
+        assert!(resolver.resolve(&pkg).is_ok());
+    }
+
+    #[test]
+    fn test_package_resolver_with_conflicts() {
+        use bend_pvm::package::DependencyResolver;
+
+        let mut resolver = DependencyResolver::new();
+        let mut pkg1 = Package::new("pkg1".to_string(), Version::new(1, 0, 0));
+        pkg1.add_dependency(Dependency::new("shared".to_string(), Version::new(1, 0, 0)));
+
+        let mut pkg2 = Package::new("pkg2".to_string(), Version::new(1, 0, 0));
+        pkg2.add_dependency(Dependency::new("shared".to_string(), Version::new(2, 0, 0)));
+
+        resolver.register(pkg1).unwrap();
+        let result = resolver.register(pkg2);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_version_from_str() {
+        let version = Version::from_str("1.2.3");
+        assert!(version.is_ok());
+        let v = version.unwrap();
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 2);
+        assert_eq!(v.patch, 3);
+    }
+
+    #[test]
+    fn test_package_name_validation() {
+        assert!(PackageManifest::is_valid_name("valid_pkg"));
+        assert!(PackageManifest::is_valid_name("my-package-123"));
+        assert!(!PackageManifest::is_valid_name(""));
+        assert!(!PackageManifest::is_valid_name("-invalid"));
+    }
+
+    #[test]
+    fn test_package_lock_creation() {
+        use bend_pvm::package::{PackageLock, PackageLockEntry};
+
+        let mut lock = PackageLock::new();
+        lock.add_entry(PackageLockEntry::new(
+            "pkg".to_string(),
+            Version::new(1, 0, 0),
+            "hash123".to_string(),
+        ));
+
+        assert_eq!(lock.entries().len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Add package manager module with semantic versioning and dependency resolution
- Implements `Package`, `Version`, `PackageRegistry`, and `PackageResolver` structs
- 22 TDD tests covering package lifecycle, versioning, and resolution

## Summary
- feat(package): add package manager module with versioning and dependencies

## Test Results
- 103 lib tests ✅
- 22 package tests ✅
- All integration tests ✅

Closes #21